### PR TITLE
Add Windows support for install instructions and undodir

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,20 @@
 
 ## Installation
 
+### Linux / macOS
+
 ```bash
 rm -rf ~/.config/nvim
 rm -rf ~/.local/share/nvim
 git clone https://github.com/clarkezone/neovimconfig.git ~/.config/nvim
+```
+
+### Windows (PowerShell)
+
+```powershell
+Remove-Item -Recurse -Force ~\AppData\Local\nvim -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force ~\AppData\Local\nvim-data -ErrorAction SilentlyContinue
+git clone https://github.com/clarkezone/neovimconfig.git ~\AppData\Local\nvim
 ```
 
 On first launch, [lazy.nvim](https://github.com/folke/lazy.nvim) will bootstrap itself and install all plugins automatically. Run `:Lazy sync` to ensure everything is up to date.

--- a/lua/clarkezone/set.lua
+++ b/lua/clarkezone/set.lua
@@ -5,7 +5,7 @@ vim.opt.nu = true
 vim.opt.relativenumber = true
 vim.opt.swapfile = false
 vim.opt.backup = false
-vim.opt.undodir = os.getenv("HOME") .. "/.vim/undodir"
+vim.opt.undodir = vim.fn.stdpath("data") .. "/undodir"
 vim.opt.undofile = true
 
 vim.opt.incsearch = true


### PR DESCRIPTION
## Summary

- **set.lua**: use `vim.fn.stdpath("data")` for undodir instead of `$HOME` which is nil on Windows
- **README**: add Windows PowerShell install instructions alongside Linux/macOS

## Test plan
- [ ] Verify undodir works on Linux/macOS (`~/.local/share/nvim/undodir`)
- [ ] Verify undodir works on Windows (`~/AppData/Local/nvim-data/undodir`)
- [ ] Test fresh install on Windows using PowerShell instructions

https://claude.ai/code/session_01PyU7o7BWbbDba9EgtLEFKb