### PR TITLE
Fix telescope tag to v0.2.1 (with v prefix)

### DIFF
--- a/lua/clarkezone/lazy.lua
+++ b/lua/clarkezone/lazy.lua
@@ -15,7 +15,7 @@ vim.opt.rtp:prepend(lazypath)
 require("lazy").setup({
 	{
 		"nvim-telescope/telescope.nvim",
-		tag = "0.2.1",
+		tag = "v0.2.1",
 		dependencies = { "nvim-lua/plenary.nvim" },
 		config = function()
 			local builtin = require("telescope.builtin")


### PR DESCRIPTION
## Summary

- Fix telescope.nvim tag from `0.2.1` to `v0.2.1` (newer releases use a `v` prefix)
- Without this, lazy.nvim fails with `pathspec 'tags/0.2.1' did not match any file(s) known to git`

## Test plan
- [ ] Run `:Lazy sync` — telescope should install without checkout errors

https://claude.ai/code/session_01PyU7o7BWbbDba9EgtLEFKb