### PR TITLE
Add dot as completion trigger for struct methods

### DIFF
--- a/lua/clarkezone/lazy.lua
+++ b/lua/clarkezone/lazy.lua
@@ -145,9 +145,18 @@ require("lazy").setup({
 			},
 			completion = {
 				documentation = { auto_show = true },
+				trigger = {
+					show_on_trigger_character = true,
+				},
 			},
 			sources = {
 				default = { "lsp", "path", "snippets", "buffer" },
+				providers = {
+					lsp = {
+						-- Trigger completion on '.' for LSP servers that don't advertise it
+						override_trigger_characters = { "." },
+					},
+				},
 			},
 		},
 	},


### PR DESCRIPTION
## Summary

- Add `.` as a completion trigger character in blink.cmp
- The Mojo LSP server doesn't advertise `.` as a trigger character, so struct method completions don't auto-show after typing a dot
- This configures blink.cmp to trigger completions on `.` for all LSP sources

## Test plan
- [ ] Open a `.mojo` file, type `my_struct.` — completion popup should appear automatically
- [ ] Verify `<C-Space>` still works as manual trigger

https://claude.ai/code/session_01PyU7o7BWbbDba9EgtLEFKb